### PR TITLE
ci: Run on MacOS only

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   rustfmt:
     name: rustfmt
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1
     - name: Install rustfmt
@@ -19,7 +19,7 @@ jobs:
 
   clippy:
     name: clippy
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1
     - name: Install clippy
@@ -28,11 +28,8 @@ jobs:
       run: cargo clippy --all
 
   test:
-    name: Test ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+    name: Test Build
+    runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1
     - name: Install rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,28 +7,8 @@ on:
   pull_request:
 
 jobs:
-  rustfmt:
-    name: rustfmt
-    runs-on: macOS-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Install rustfmt
-      run: rustup component add rustfmt
-    - name: Run rustfmt
-      run: cargo fmt --all -- --check
-
-  clippy:
-    name: clippy
-    runs-on: macOS-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Install clippy
-      run: rustup component add clippy
-    - name: Run clippy
-      run: cargo clippy --all
-
-  test:
-    name: Test Build
+  build:
+    name: build
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1
@@ -47,3 +27,9 @@ jobs:
       run: cargo build --all --verbose
     - name: Run tests
       run: cargo test --all --verbose
+    - name: Install rustfmt and clippy
+      run: rustup component add rustfmt clippy
+    - name: Run rustfmt
+      run: cargo fmt --all -- --check
+    - name: Run clippy
+      run: cargo clippy --all


### PR DESCRIPTION
CI runs much faster in MacOS, plus realistically everything that runs on MacOS, will also run in Linux, at least for the Rust's ecosystem.

Part of this is made because Windows is terrible at filesystem stuff and so is making CI red.

And this boosts CI speeds by a lot.